### PR TITLE
Fix typo in test status macros

### DIFF
--- a/src/main/cc/common_cpp/testing/status_macros.h
+++ b/src/main/cc/common_cpp/testing/status_macros.h
@@ -28,6 +28,6 @@
   lhs = *std::move(statusor)
 
 #define STATUS_MACROS__CONCAT_INNER(x, y) x##y
-#define STATUS_MACROS__CONCAT(x, y) STATUS_MACROS_CONCAT_IMPL(x, y)
+#define STATUS_MACROS__CONCAT(x, y) STATUS_MACROS__CONCAT_INNER(x, y)
 
 #endif  // SRC_MAIN_CC_COMMON_CPP_TESTING_STATUS_MACROS_H_


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/common-cpp/12)
<!-- Reviewable:end -->
