### PR TITLE
change com_github_glog_glog_repo to com_github_google_glog_repo

### DIFF
--- a/build/com_github_google_glog/repo.bzl
+++ b/build/com_github_google_glog/repo.bzl
@@ -19,11 +19,11 @@ Repository rules/macros for GLog.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("//build/com_github_gflags_gflags:repo.bzl", "com_github_gflags_gflags_repo")
 
-def com_github_glog_glog_repo():
+def com_github_google_glog_repo():
     com_github_gflags_gflags_repo()
-    if "com_github_glog_glog" not in native.existing_rules():
+    if "com_github_google_glog" not in native.existing_rules():
         http_archive(
-            name = "com_github_glog_glog",
+            name = "com_github_google_glog",
             sha256 = "f28359aeba12f30d73d9e4711ef356dc842886968112162bc73002645139c39c",
             strip_prefix = "glog-0.4.0",
             urls = ["https://github.com/google/glog/archive/v0.4.0.tar.gz"],

--- a/build/com_google_private_join_and_compute/repo.bzl
+++ b/build/com_google_private_join_and_compute/repo.bzl
@@ -19,6 +19,7 @@ Repository rules/macros for Private Join & Compute.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def com_google_private_join_and_compute_repo():
+    """Installs deps inclusing transitive deps for panel_exchange_client."""
     if "com_google_private_join_and_compute" not in native.existing_rules():
         commit = "8bc01b3f0b41a8ee80acee9ad5ae2c45bbdaef88"
         http_archive(

--- a/build/com_google_private_join_and_compute/repo.bzl
+++ b/build/com_google_private_join_and_compute/repo.bzl
@@ -29,3 +29,10 @@ def com_google_private_join_and_compute_repo():
                 "https://github.com/google/private-join-and-compute/archive/%s.zip" % commit,
             ],
         )
+    if "com_github_glog_glog" not in native.existing_rules():
+        http_archive(
+            name = "com_github_glog_glog",
+            sha256 = "21bc744fb7f2fa701ee8db339ded7dce4f975d0d55837a97be7d46e8382dea5a",
+            strip_prefix = "glog-0.5.0",
+            url = "https://github.com/google/glog/archive/v0.5.0.zip",
+        )

--- a/build/com_google_private_join_and_compute/repo.bzl
+++ b/build/com_google_private_join_and_compute/repo.bzl
@@ -19,7 +19,7 @@ Repository rules/macros for Private Join & Compute.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def com_google_private_join_and_compute_repo():
-    """Installs deps inclusing transitive deps for panel_exchange_client."""
+    """Installs deps inclusing transitive deps for private join and compute."""
     if "com_google_private_join_and_compute" not in native.existing_rules():
         commit = "8bc01b3f0b41a8ee80acee9ad5ae2c45bbdaef88"
         http_archive(

--- a/build/common_cpp_repositories.bzl
+++ b/build/common_cpp_repositories.bzl
@@ -21,7 +21,7 @@ load("//build/com_google_protobuf:repo.bzl", "com_google_protobuf_repo")
 load("//build/boringssl:repo.bzl", "boringssl_repo")
 load("//build/farmhash:repo.bzl", "farmhash_repo")
 load("//build/com_google_googletest:repo.bzl", "com_google_googletest_repo")
-load("//build/com_github_glog_glog:repo.bzl", "com_github_glog_glog_repo")
+load("//build/com_github_google_glog:repo.bzl", "com_github_google_glog_repo")
 load("//build/com_google_private_join_and_compute:repo.bzl", "com_google_private_join_and_compute_repo")
 
 def common_cpp_repositories():
@@ -33,5 +33,5 @@ def common_cpp_repositories():
     boringssl_repo()
     farmhash_repo()
     com_google_googletest_repo()
-    com_github_glog_glog_repo()
+    com_github_google_glog_repo()
     com_google_private_join_and_compute_repo()

--- a/src/main/cc/common_cpp/macros/macros.h
+++ b/src/main/cc/common_cpp/macros/macros.h
@@ -35,6 +35,14 @@
       MACROS__CONCAT(status_or_value, __COUNTER__), lhs, rexpr, message)
 #endif
 
+#ifndef NULL_CHECK
+#define NULL_CHECK(val)  \
+  ({                     \
+    assert(val != NULL); \
+    val;                 \
+  })
+#endif
+
 // Internal helper.
 #define MACROS__ASSIGN_OR_RETURN_IMPL(statusor, lhs, rexpr) \
   auto statusor = (rexpr);                                  \


### PR DESCRIPTION
I was seeing some issues with importing com_github_glog_glog vs com_github_google_glog. Its inconsistent across the dependencies and the compiler complains to me about duplicate functions from both sources.

For now, I've gone with the repo consistent google_glog, added glog_glog as a join and compute dependency, and added a macro to avoid using glog for repos that use both private-join-and-compute and private-membership since they import it with different names each.

There is probably an easier way to just alias this but I'm not sure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/common-cpp/21)
<!-- Reviewable:end -->
