### PR TITLE
Fix include prefix

### DIFF
--- a/src/main/cc/common_cpp/protobuf_util/textproto_io.cc
+++ b/src/main/cc/common_cpp/protobuf_util/textproto_io.cc
@@ -15,7 +15,7 @@
 #ifndef SRC_MAIN_CC_COMMON_CPP_PROTOBUF_UTIL_TEXTPROTO_IO_H_
 #define SRC_MAIN_CC_COMMON_CPP_PROTOBUF_UTIL_TEXTPROTO_IO_H_
 
-#include "src/main/cc/common_cpp/protobuf_util/textproto_io.h"
+#include "common_cpp/protobuf_util/textproto_io.h"
 
 #include <fcntl.h>
 


### PR DESCRIPTION
strip_prefix includes the src/main/cc and can be safely left out. This matches other includes across the repo

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/common-cpp/26)
<!-- Reviewable:end -->
