### PR TITLE
Update library boringssl and brotli version to solve clang error.

### DIFF
--- a/build/boringssl/repo.bzl
+++ b/build/boringssl/repo.bzl
@@ -30,7 +30,6 @@ def boringssl_repo():
             sha256 = "e665a65074df16891f682a682741816f34b70c380ab37d4b7dd408ac091efffc",
             strip_prefix = "boringssl-%s" % commit,
             urls = [
-                #            "https://storage.googleapis.com/grpc-bazel-mirror/github.com/google/boringssl/archive/%s.tar.gz" % commit,
                 "https://github.com/google/boringssl/archive/%s.tar.gz" % commit,
             ],
         )

--- a/build/boringssl/repo.bzl
+++ b/build/boringssl/repo.bzl
@@ -22,14 +22,15 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def boringssl_repo():
     if "boringssl" not in native.existing_rules():
+        commit = "e706c2ee12d5d5927cc10a804fefbae3da2d66b3"  # 12/12/2023, branch: master-with-bazel
         http_archive(
             name = "boringssl",
             # Use github mirror instead of https://boringssl.googlesource.com/boringssl
             # to obtain a boringssl archive with consistent sha256
-            sha256 = "19870fcdbdfc61217ad814077483347a5b2bf4b3bbb5f6c983edac7856a40bbb",
-            strip_prefix = "boringssl-bcc01b6c66b1c6fa2816b108e50a544b757fbd7b",
+            sha256 = "e665a65074df16891f682a682741816f34b70c380ab37d4b7dd408ac091efffc",
+            strip_prefix = "boringssl-%s" % commit,
             urls = [
-                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/google/boringssl/archive/bcc01b6c66b1c6fa2816b108e50a544b757fbd7b.tar.gz",
-                "https://github.com/google/boringssl/archive/bcc01b6c66b1c6fa2816b108e50a544b757fbd7b.tar.gz",
+                #            "https://storage.googleapis.com/grpc-bazel-mirror/github.com/google/boringssl/archive/%s.tar.gz" % commit,
+                "https://github.com/google/boringssl/archive/%s.tar.gz" % commit,
             ],
         )

--- a/build/com_google_brotli/repo.bzl
+++ b/build/com_google_brotli/repo.bzl
@@ -20,13 +20,12 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def com_google_brotli_repo():
     if "com_google_brotli" not in native.existing_rules():
-        commit = "ed738e842d2fbdf2d6459e39267a633c4a9b2f5d"  # 2023-08-31, v1.1.0
+        version = "1.1.0"  # 2023-08-31
         http_archive(
             name = "org_brotli",
-            sha256 = "a68ec12a898abc9cf248f21362620562041b7aab4d623ecd736f39bedf5002a0",
-            strip_prefix = "brotli-%s" % commit,
+            sha256 = "9d7ec775e67cdb3d0328f63f314b381d57f0f985499bbf2e55b15138a3621b19",
+            strip_prefix = "brotli-1.1.0",
             urls = [
-                "https://mirror.bazel.build/github.com/google/brotli/archive/%s.zip" % commit,
-                "https://github.com/google/brotli/archive/%s.zip" % commit,
+                "https://github.com/google/brotli/archive/refs/tags/v%s.zip" % version,
             ],
         )

--- a/build/com_google_brotli/repo.bzl
+++ b/build/com_google_brotli/repo.bzl
@@ -24,7 +24,7 @@ def com_google_brotli_repo():
         http_archive(
             name = "org_brotli",
             sha256 = "9d7ec775e67cdb3d0328f63f314b381d57f0f985499bbf2e55b15138a3621b19",
-            strip_prefix = "brotli-1.1.0",
+            strip_prefix = "brotli-%s" % version,
             urls = [
                 "https://github.com/google/brotli/archive/refs/tags/v%s.zip" % version,
             ],

--- a/build/com_google_brotli/repo.bzl
+++ b/build/com_google_brotli/repo.bzl
@@ -20,13 +20,13 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def com_google_brotli_repo():
     if "com_google_brotli" not in native.existing_rules():
-        commit = "68f1b90ad0d204907beb58304d0bd06391001a4d"
+        commit = "ed738e842d2fbdf2d6459e39267a633c4a9b2f5d"  # 2023-08-31, v1.1.0
         http_archive(
             name = "org_brotli",
-            sha256 = "fec5a1d26f3dd102c542548aaa704f655fecec3622a24ec6e97768dcb3c235ff",
+            sha256 = "a68ec12a898abc9cf248f21362620562041b7aab4d623ecd736f39bedf5002a0",
             strip_prefix = "brotli-%s" % commit,
             urls = [
                 "https://mirror.bazel.build/github.com/google/brotli/archive/%s.zip" % commit,
-                "https://github.com/google/brotli/archive/%s.zip" % commit,  # 2021-08-18
+                "https://github.com/google/brotli/archive/%s.zip" % commit,
             ],
         )

--- a/build/common_cpp_repositories.bzl
+++ b/build/common_cpp_repositories.bzl
@@ -34,9 +34,9 @@ def common_cpp_repositories():
     """
     Adds all external repos necessary for common-cpp.
     """
+    boringssl_repo()
     com_google_absl_repo()
     rules_proto()
-    boringssl_repo()
     farmhash_repo()
     com_google_googletest_repo()
     com_github_google_glog_repo()

--- a/build/common_cpp_repositories.bzl
+++ b/build/common_cpp_repositories.bzl
@@ -34,9 +34,9 @@ def common_cpp_repositories():
     """
     Adds all external repos necessary for common-cpp.
     """
-    boringssl_repo()
     com_google_absl_repo()
     rules_proto()
+    boringssl_repo()
     farmhash_repo()
     com_google_googletest_repo()
     com_github_google_glog_repo()


### PR DESCRIPTION
New version of Clang raises error 
```
external/boringssl/src/crypto/x509/t_x509.c:500:18: error: variable 'l' set but not used [-Werror,-Wunused-but-set-variable]
    int ret = 0, l, i;
```
So update library version to fix it.